### PR TITLE
Fix issues with lazy init

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -229,7 +229,8 @@ Options
 
 `type`: Page file extension.  It's recommended to use a different extension for pages and components, so that svelte-view-engine doesn't unnecessarily build non-page components it finds in the pages directory (e.g. .html for pages and .svelte for other components).  Defaults to `"html"`.
 
-`init`: Find all pages (files of `type` in `dir`) and initialise them on startup.  Defaults to `false`.
+`init`: Find all pages (files of `type` in `dir`) and initialize them on
+startup. If false, pages will be lazy initialized on render.  Defaults to `true`.
 
 `buildDir`: Where to output built pages and their CSS and JS files.
 

--- a/src/Engine.js
+++ b/src/Engine.js
@@ -115,7 +115,7 @@ module.exports = class {
 	
 	async render(path, locals, callback, forEmail=false) {
 		if (!this.template.ready) {
-			await this.template._init();
+			await this.template._init;
 		}
 		
 		if (!osPath.isAbsolute(path)) {

--- a/src/Engine.js
+++ b/src/Engine.js
@@ -18,7 +18,8 @@ module.exports = class {
 		
 		this.scheduler = buildScheduler(config);
 		this.pages = {};
-		this.init();
+		// this is used in a test
+		this._initPromise = this.init();
 		this.render = this.render.bind(this);
 	}
 	
@@ -40,7 +41,7 @@ module.exports = class {
 		}
 		
 		if (this.config.init) {
-			this.initPages();
+			return this.initPages();
 		}
 	}
 	
@@ -115,7 +116,7 @@ module.exports = class {
 	
 	async render(path, locals, callback, forEmail=false) {
 		if (!this.template.ready) {
-			await this.template._init;
+			await this.template.load();
 		}
 		
 		if (!osPath.isAbsolute(path)) {

--- a/src/Page.js
+++ b/src/Page.js
@@ -331,7 +331,7 @@ module.exports = class {
 			return this.template.render({
 				head,
 				html,
-				css: css.code,
+				css: css && css.code,
 				js: js.code,
 				jsPath,
 				cssPath,

--- a/src/Page.js
+++ b/src/Page.js
@@ -91,18 +91,32 @@ module.exports = class {
 	
 	build() {
 		let {promise, child: buildProcess} = this.runBuildScript();
-		let complete = promise.then(() => this.init());
 		
 		return {
-			promise,
 			buildProcess,
-			complete,
+			complete: promise,
 		};
 	}
 	
-	async init(priority=false) {
+	/**
+	 * Init the page. If init is already in flight, the existing promise will be
+	 * returned
+	 * @param {*} priority - the priority of the build in the queue if needed
+	 */
+	async init(priority = false, force = false) {
+		// this makes sure the page will only be initialized once since both page build
+		// and engine init may initialize the page
+		if (!this._initPromise) {
+			this._initPromise = this.doInit(priority).then(() => {
+				this._initPromise = undefined;
+			});
+		}
+		return this._initPromise;
+	}
+
+	async doInit(priority=false) {
 		if (!await this.buildFile.exists()) {
-			return this.scheduler.scheduleBuild(this, priority);
+			await this.scheduler.scheduleBuild(this, priority);
 		}
 		
 		try {

--- a/src/Template.js
+++ b/src/Template.js
@@ -23,11 +23,30 @@ module.exports = class {
 				this.load();
 			});
 		}
-		
-		this._init = this.load();
+
+		// only eager load if init is set to true in config, otherwise engine.render
+		// will lazy load the template
+		if (config.init) {
+			this.load();
+		}
+	}
+
+	/**
+	 * Load the template. If load is already in flight, the existing promise will
+	 * be returned
+	 */
+	async load() {
+		// this makes sure the template will only be initialized once since the
+		// constructor or the render method might
+		if (!this._loadPromise) {
+			this._loadPromise = this.doLoad().then(() => {
+				this._loadPromise = undefined;
+			});
+		}
+		return this._loadPromise;
 	}
 	
-	async load() {
+	async doLoad() {
 		let str = await fs(this.path).read();
 		
 		// process include directives first

--- a/test/build.js
+++ b/test/build.js
@@ -1,6 +1,9 @@
 let yargs = require("yargs");
 let fs = require("flowfs");
 
+// default the --css option to true
+yargs.option('css', { type: 'boolean', default: true });
+
 (async function() {
 	let {
 		name,
@@ -27,9 +30,14 @@ let fs = require("flowfs");
 				};
 			`,
 			
-			css: {
-				code: "css",
-			},
+			// this will add a css property to server if css is set to false. If not
+			// specified, it will default to true. This is to simulate a component
+			// without a style block
+			...(yargs.argv.css && {
+				css: {
+					code: "css"
+				}
+			}),
 		},
 		
 		client: {


### PR DESCRIPTION
The PR fixes some bugs around lazy initializing pages and the template. The init method on Page and the load method on Template now will prevent multiple concurrent runs which was causing the tests to fail sometimes and intermittent errors at runtime. Also, page.build was causing pages to be initialized even when init was false. Now if init is false, only calling render will init the page.

A second more minor issue this PR fixes is that an error was thrown if a svelte component didn't have a style block.